### PR TITLE
Set timeouts for workflow steps in CI/CD pipelines

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Deploy to Dev Environment
         id: deploy
+        timeout-minutes: 10
         run: |
           # Your deployment commands here
           # For example: (--MOCKING FOR NOW--)
@@ -53,6 +54,7 @@ jobs:
       # Deployment Verification Tests
       - name: Run Post-Deployment Tests
         id: verification
+        timeout-minutes: 10 #timeout for this step
         if: success() && env.DEPLOY_STATUS == 'success'
         run: |
           # Run smoke tests against the deployed application

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -43,6 +43,7 @@ jobs:
         
       - name: Deploy to Production Environment
         id: deploy
+        timeout-minutes: 20 #deployment can be long depending on artifacts and environment configurations
         run: |
           # Your production deployment commands here
           echo "Deploying version ${{ github.event.inputs.version }} to PROD environment"
@@ -55,6 +56,7 @@ jobs:
       # Deployment Verification Tests
       - name: Run Post-Deployment Verification
         id: verification
+        timeout-minutes: 15 #timeout for this step
         if: success() && env.DEPLOY_STATUS == 'success'
         run: |
           # Comprehensive verification suite for production

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -30,6 +30,7 @@ jobs:
     # Build the project and run tests
     - name: Build and test with Maven
       run: mvn -B clean verify
+      timeout-minutes: 15 # timeout for just this step
 
     # Upload test reports if tests fail
     - name: Upload Test Reports (if failure)
@@ -44,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run after build and tests pass
     needs: build-and-test
+    timeout-minutes: 15 # timeout for this 'static-analysis' job
 
     steps:
     - name: Checkout code
@@ -72,6 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run after build and tests pass
     needs: build-and-test
+    timeout-minutes: 10 # timeout for 'security-scan' job
 
     steps:
     - name: Checkout code

--- a/.github/workflows/pr-pipeline.yml
+++ b/.github/workflows/pr-pipeline.yml
@@ -31,12 +31,14 @@ jobs:
     # Build the project and run tests
     - name: Build and test with Maven
       run: mvn -B clean verify
+      timeout-minutes: 15 # timeout for just this step
 
   # Run static code analysis to ensure code quality
   static-analysis:
     runs-on: ubuntu-latest
     # Only run after build and tests pass
     needs: build-and-test
+    timeout-minutes: 15 # timeout for this 'static-analysis' job
 
     steps:
     - name: Checkout code
@@ -62,6 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run after build and tests pass
     needs: build-and-test
+    timeout-minutes: 10 # timeout for 'security-scan' job
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
### Description

This pull request adds `timeout-minutes` configurations to various steps in CI/CD pipelines, including deployment, verification, build, static analysis, and security scans. These changes apply to production, development, and PR workflows to prevent prolonged step execution and unnecessary pipeline hangs.

### Checklist

- [x] Tests are updated or added if necessary  
- [x] Documentation has been updated where applicable  
- [x] Changes are reviewed and approved