### PR TITLE
test: add LocalStack integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A serverless application for file processing, metadata extraction and SNS notifi
 - Spring Boot
 - **Spring Cloud Function**: Abstracts the business logic to be portable across cloud providers (AWS Lambda).
 - Maven
+- LocalStack
+- Testcontainers
 ### Cloud Services (AWS)
 - AWS Lambda
 - AWS S3
@@ -45,3 +47,21 @@ flowchart TD
 ### Notifications toggle
 
 Notifications are optional. The `MetaNotifier` bean is only created when `notifications.enabled=true` (or `NOTIFICATIONS_ENABLED=true` in the environment). This allows running the function without SNS configured (e.g., local dev/CI) while still processing S3 events normally. When disabled, notification publishing is skipped.
+
+## Local testing with LocalStack
+
+This project includes integration tests that use LocalStack (via Testcontainers) to validate the S3 → Lambda (function) → SNS → SQS flow.
+
+What gets verified:
+- An S3 event triggers the function, the function extracts file metadata, and a notification is published to SNS.
+- The SNS message is delivered to an SQS subscription, and the test asserts the message content.
+- A negative‑path test confirms that when notifications are disabled, no message is published, while the function still returns metadata.
+
+Notes:
+- If Docker is not available, the LocalStack tests are skipped automatically.
+- The tests dynamically wire the application properties to point the SDK to LocalStack.
+
+Troubleshooting:
+- Ensure Docker is running and enough memory/CPU is allocated to it.
+- If tests are flaky in slow environments, increase polling timeouts; see the constants in `MetaPingApplicationTests`.
+- Port conflicts or firewall/proxy issues can interfere with Testcontainers; check Docker logs if the LocalStack container fails to start.

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
     <aws.lambda.events.version>3.11.3</aws.lambda.events.version>
     <aws.lambda.core.version>1.2.3</aws.lambda.core.version>
     <aws.sdk2.sns.version>2.25.64</aws.sdk2.sns.version>
+    <aws.sdk2.sqs.version>2.25.64</aws.sdk2.sqs.version>
+    <testcontainers.version>1.20.3</testcontainers.version>
     <sonar.version>5.5.0.6356</sonar.version>
     <jacoco.version>0.8.12</jacoco.version>
     <!-- SonarCloud Configuration -->
@@ -87,6 +89,26 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sns</artifactId>
       <version>${aws.sdk2.sns.version}</version>
+    </dependency>
+    <!-- AWS SDK v2 SQS (test usage for verifying SNS delivery via SQS subscription) -->
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sqs</artifactId>
+      <version>${aws.sdk2.sqs.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Testcontainers: JUnit 5 + LocalStack -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>localstack</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/src/main/java/com/iam/metaping/config/SnsProperties.java
+++ b/src/main/java/com/iam/metaping/config/SnsProperties.java
@@ -7,6 +7,8 @@ public class SnsProperties {
 
     private String topicArn;
     private String region;
+    /** Optional endpoint override to be used for integration tests (e.g., 'http://localhost:4566' for LocalStack) */
+    private String endpoint;
 
     public String getTopicArn() {
         return topicArn;
@@ -22,5 +24,13 @@ public class SnsProperties {
 
     public void setRegion(String region) {
         this.region = region;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
     }
 }

--- a/src/test/java/com/iam/metaping/MetaPingApplicationTests.java
+++ b/src/test/java/com/iam/metaping/MetaPingApplicationTests.java
@@ -1,7 +1,0 @@
-package com.iam.metaping;
-
-import org.junit.jupiter.api.Disabled;
-
-@Disabled("Removed as unnecessary: dummy context test provided no coverage")
-class MetaPingApplicationTests {
-}

--- a/src/test/java/com/iam/metaping/integration/MetaPingApplicationTests.java
+++ b/src/test/java/com/iam/metaping/integration/MetaPingApplicationTests.java
@@ -1,0 +1,294 @@
+package com.iam.metaping.integration;
+
+import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.iam.metaping.function.MetaPingFunction;
+import com.iam.metaping.integration.helpers.TestS3EventFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.Assumptions;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.DockerClientFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
+import software.amazon.awssdk.services.sns.model.SubscribeRequest;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SNS;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+// Integration test using LocalStack to validate:
+// S3 event -> function extracts metadata -> publishes to SNS -> delivered to SQS subscription
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MetaPingApplicationTests {
+    private static final boolean DOCKER_AVAILABLE;
+    private static final String LOCALSTACK_ACCOUNT_ID = "000000000000"; // LocalStack default account id
+
+    // Test constants
+    private static final String TOPIC_NAME = "meta-ping-test";
+    private static final String QUEUE_NAME = "meta-ping-queue";
+    private static final String EXPECTED_SUBJECT = "Meta-Ping Notification: New File Uploaded";
+    private static final String EXPECTED_FILE_NAME = "test-file.pdf";
+    private static final String EXPECTED_FILE_TYPE = "application/pdf";
+    private static final long EXPECTED_FILE_SIZE = 1024L;
+    private static final int POLL_TIMEOUT_SECONDS = 30;
+    private static final int LONG_POLL_SECONDS = 5;
+
+    static String topicArn;
+    static String queueUrl;
+
+    @Autowired
+    MetaPingFunction function;
+
+    @Container
+    static LocalStackContainer localstack;
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        if (DOCKER_AVAILABLE) {
+            // Enable notification path in the Spring context and target LocalStack
+            registry.add("notifications.enabled", () -> "true");
+            registry.add("aws.sns.topic-arn", () -> topicArn);
+            registry.add("aws.sns.region", localstack::getRegion);
+            registry.add("aws.sns.endpoint", () -> localstack.getEndpointOverride(SNS).toString());
+        } else {
+            // Disable notifications to avoid creating MetaNotifier/SnsPublisher in environments without Docker
+            registry.add("notifications.enabled", () -> "false");
+            registry.add("aws.sns.topic-arn", () -> "");
+            registry.add("aws.sns.region", () -> "us-east-1");
+        }
+    }
+
+    // Start LocalStack once for the test class (only if Docker is available)
+    static {
+        boolean available;
+        try {
+            DockerClientFactory.instance().client();
+            available = true;
+        } catch (Throwable t) {
+            available = false;
+        }
+        DOCKER_AVAILABLE = available;
+
+        if (DOCKER_AVAILABLE) {
+            localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.8"))
+                    .withServices(SNS, SQS);
+            localstack.start();
+            setupStaticInfra();
+        } else {
+            localstack = null;
+        }
+    }
+
+    // Provision SNS topic and SQS queue and wire the subscription (once per class)
+    private static void setupStaticInfra() {
+        AwsBasicCredentials creds = AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey());
+        Region region = Region.of(localstack.getRegion());
+
+        try (SnsClient sns = buildSnsClient(creds, region);
+             SqsClient sqs = buildSqsClient(creds, region)) {
+
+            // Create SNS topic and SQS queue for the test
+            topicArn = sns.createTopic(CreateTopicRequest.builder().name(TOPIC_NAME).build()).topicArn();
+            queueUrl = sqs.createQueue(CreateQueueRequest.builder().queueName(QUEUE_NAME).build()).queueUrl();
+
+            String queueArn = getQueueArnWithFallback(sqs, queueUrl, QUEUE_NAME);
+
+            // Allow SNS topic to send to the SQS queue
+            applyQueuePolicyAllowSns(sqs, queueUrl, queueArn, topicArn);
+
+            // Subscribe the queue to the topic (protocol = sqs, endpoint = queue ARN)
+            sns.subscribe(SubscribeRequest.builder()
+                    .topicArn(topicArn)
+                    .protocol("sqs")
+                    .endpoint(queueArn)
+                    .build());
+        }
+    }
+
+    // Build SDK v2 SNS client pointing to LocalStack
+    private static SnsClient buildSnsClient(AwsBasicCredentials creds, Region region) {
+        return SnsClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(SNS))
+                .region(region)
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
+                .build();
+    }
+
+    // Build SDK v2 SQS client pointing to LocalStack
+    private static SqsClient buildSqsClient(AwsBasicCredentials creds, Region region) {
+        return SqsClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(SQS))
+                .region(region)
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
+                .build();
+    }
+
+
+
+    @BeforeAll
+    void setupInfra() {
+        // Skip the test suite gracefully if Docker is not available
+        Assumptions.assumeTrue(DOCKER_AVAILABLE, "Docker is not available; skipping LocalStack integration test");
+
+        // Provide credentials for DefaultCredentialsProvider so SnsPublisher can publish to LocalStack
+        System.setProperty("aws.accessKeyId", localstack.getAccessKey());
+        System.setProperty("aws.secretAccessKey", localstack.getSecretKey());
+    }
+
+
+    @Test
+    @DisplayName("S3 event triggers metadata extraction and publishes to SNS (verified via SQS subscription)")
+    void shouldPublishMetadataToSns() {
+       // Given: a synthetic S3 event representing an uploaded file
+        Assumptions.assumeTrue(DOCKER_AVAILABLE, "Docker is not available; skipping LocalStack integration test");
+        S3Event event = TestS3EventFactory.create(
+                "meta-ping-bucket",
+                EXPECTED_FILE_NAME,
+                EXPECTED_FILE_SIZE
+        );
+
+        // When: invoke function (extracts metadata and attempts SNS publish)
+        function.apply(event);
+
+        // Then: the SNS notification should be delivered to the subscribed SQS queue
+        AwsBasicCredentials creds = AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey());
+        Region region = Region.of(localstack.getRegion());
+        URI sqsEndpoint = localstack.getEndpointOverride(SQS);
+
+        try (SqsClient sqs = SqsClient.builder()
+                .endpointOverride(sqsEndpoint)
+                .region(region)
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
+                .build()) {
+
+            String qUrl = sqs.getQueueUrl(GetQueueUrlRequest.builder().queueName(QUEUE_NAME).build()).queueUrl();
+
+            boolean found = pollForNotification(sqs, qUrl); // envelope + content assertions inside
+
+            assertTrue(found, "Expected SNS notification to be delivered to SQS subscription");
+        }
+    }
+
+    // Retrieve queue ARN via API; used by policy + subscription
+    private static String getQueueArn(SqsClient sqs, String queueUrl) {
+        return sqs.getQueueAttributes(GetQueueAttributesRequest.builder()
+                        .queueUrl(queueUrl)
+                        .attributeNames(QueueAttributeName.QUEUE_ARN)
+                        .build())
+                .attributes()
+                .get(QueueAttributeName.QUEUE_ARN);
+    }
+
+    // LocalStack sometimes delays QueueArn; build a deterministic fallback ARN when missing
+    private static String getQueueArnWithFallback(SqsClient sqs, String queueUrl, String queueName) {
+        String arn = getQueueArn(sqs, queueUrl);
+        if (arn == null || arn.isBlank()) {
+            arn = String.format("arn:aws:sqs:%s:%s:%s", localstack.getRegion(), LOCALSTACK_ACCOUNT_ID, queueName);
+        }
+        return arn;
+    }
+
+    // Attach a minimal SQS policy that allows the SNS topic to send messages to the queue
+    private static void applyQueuePolicyAllowSns(SqsClient sqs, String queueUrl, String queueArn, String topicArn) {
+        String policy = ("""
+                {
+                  "Version":"2012-10-17",
+                  "Statement":[
+                    {
+                      "Sid":"Allow-SNS-SendMessage",
+                      "Effect":"Allow",
+                      "Principal":"*",
+                      "Action":"sqs:SendMessage",
+                      "Resource":"%s",
+                      "Condition":{ "ArnEquals": { "aws:SourceArn":"%s" } }
+                    }
+                  ]
+                }
+                """).formatted(queueArn, topicArn);
+
+        sqs.setQueueAttributes(SetQueueAttributesRequest.builder()
+                .queueUrl(queueUrl)
+                .attributes(Map.of(QueueAttributeName.POLICY, policy))
+                .build());
+    }
+
+    // Poll SQS for the SNS-delivered message and validate both the envelope and content
+    private static boolean pollForNotification(SqsClient sqs, String queueUrl) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Instant until = Instant.now().plus(Duration.ofSeconds(POLL_TIMEOUT_SECONDS));
+        while (Instant.now().isBefore(until)) {
+            List<Message> messages = sqs.receiveMessage(ReceiveMessageRequest.builder()
+                            .queueUrl(queueUrl)
+                            .maxNumberOfMessages(10)
+                            .waitTimeSeconds(LONG_POLL_SECONDS)
+                            .build())
+                    .messages();
+            for (Message m : messages) {
+                String body = m.body();
+                if (parseSnsEnvelopeOk(objectMapper, body)) {
+                    return true;
+                }
+                // Fallback: substring check for flakiness across LocalStack variants
+                if (body != null && body.contains("New File Uploaded") && body.contains(EXPECTED_FILE_NAME)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    // Parse the standard SNS-over-SQS JSON envelope and check expected fields + message body
+    private static boolean parseSnsEnvelopeOk(ObjectMapper objectMapper, String body) {
+        if (body == null || body.isBlank()) return false;
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            String type = root.path("Type").asText("");
+            String subject = root.path("Subject").asText("");
+            String topicFromMsg = root.path("TopicArn").asText("");
+            String message = root.path("Message").asText("");
+
+            boolean envelopeOk = "Notification".equals(type)
+                    && topicArn != null && topicArn.equals(topicFromMsg)
+                    && EXPECTED_SUBJECT.equals(subject);
+
+            boolean contentOk = message.contains("New File Uploaded:")
+                    && message.contains("Name: " + EXPECTED_FILE_NAME)
+                    && message.contains("Type: " + EXPECTED_FILE_TYPE)
+                    && message.contains("Size: " + EXPECTED_FILE_SIZE + " bytes");
+
+            return envelopeOk && contentOk;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/com/iam/metaping/integration/MetaPingNotificationsDisabledIT.java
+++ b/src/test/java/com/iam/metaping/integration/MetaPingNotificationsDisabledIT.java
@@ -1,0 +1,216 @@
+package com.iam.metaping.integration;
+
+import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.iam.metaping.function.MetaPingFunction;
+import com.iam.metaping.integration.helpers.TestS3EventFactory;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest;
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest;
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
+import software.amazon.awssdk.services.sqs.model.SetQueueAttributesRequest;
+import software.amazon.awssdk.services.sns.model.SubscribeRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SNS;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+/**
+ * Integration test variant with notifications disabled: the function should still
+ * parse metadata but must not publish anything (queue remains empty).
+ */
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MetaPingNotificationsDisabledIT {
+
+    private static final boolean DOCKER_AVAILABLE;
+
+    private static final String TOPIC_NAME = "meta-ping-disabled-test";
+    private static final String QUEUE_NAME = "meta-ping-disabled-queue";
+
+    private static final String EXPECTED_FILE_NAME = "test-file.pdf";
+    private static final String EXPECTED_FILE_TYPE = "application/pdf";
+    private static final long EXPECTED_FILE_SIZE = 1024L;
+
+    private static final int POLL_TIMEOUT_SECONDS = 10; // shorter since we expect no messages
+    private static final int LONG_POLL_SECONDS = 2;
+
+    static String queueUrl;
+
+    @Autowired
+    MetaPingFunction function;
+
+    @Container
+    static LocalStackContainer localstack;
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        // Disable notifications so MetaNotifier bean is not created
+        registry.add("notifications.enabled", () -> "false");
+        // Provide default region to satisfy configuration consumers
+        registry.add("aws.sns.region", () -> DOCKER_AVAILABLE ? localstack.getRegion() : "us-east-1");
+        // Intentionally leave topic-arn empty; no publishing should occur
+        registry.add("aws.sns.topic-arn", () -> "");
+    }
+
+    static {
+        boolean available;
+        try {
+            DockerClientFactory.instance().client();
+            available = true;
+        } catch (Throwable t) {
+            available = false;
+        }
+        DOCKER_AVAILABLE = available;
+
+        if (DOCKER_AVAILABLE) {
+            localstack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.8"))
+                    .withServices(SNS, SQS);
+            localstack.start();
+            setupStaticInfra();
+        } else {
+            localstack = null;
+        }
+    }
+
+    private static void setupStaticInfra() {
+        AwsBasicCredentials creds = AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey());
+        Region region = Region.of(localstack.getRegion());
+
+        try (SnsClient sns = SnsClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(SNS))
+                .region(region)
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
+                .build();
+             SqsClient sqs = SqsClient.builder()
+                     .endpointOverride(localstack.getEndpointOverride(SQS))
+                     .region(region)
+                     .credentialsProvider(StaticCredentialsProvider.create(creds))
+                     .build()) {
+
+            // Create a topic and a queue. We DO subscribe the queue to topic so that
+            // if anything were published by mistake, it would be observable in SQS.
+            String topicArn = sns.createTopic(CreateTopicRequest.builder().name(TOPIC_NAME).build()).topicArn();
+            queueUrl = sqs.createQueue(CreateQueueRequest.builder().queueName(QUEUE_NAME).build()).queueUrl();
+
+            String queueArn = sqs.getQueueAttributes(GetQueueAttributesRequest.builder()
+                    .queueUrl(queueUrl)
+                    .attributeNames(QueueAttributeName.QUEUE_ARN)
+                    .build()).attributes().get(QueueAttributeName.QUEUE_ARN);
+
+            // Allow SNS topic to send to the SQS queue
+            String policy = ("""
+                    {
+                      "Version":"2012-10-17",
+                      "Statement":[
+                        {
+                          "Sid":"Allow-SNS-SendMessage",
+                          "Effect":"Allow",
+                          "Principal":"*",
+                          "Action":"sqs:SendMessage",
+                          "Resource":"%s",
+                          "Condition":{ "ArnEquals": { "aws:SourceArn":"%s" } }
+                        }
+                      ]
+                    }
+                    """).formatted(queueArn, topicArn);
+
+            sqs.setQueueAttributes(SetQueueAttributesRequest.builder()
+                    .queueUrl(queueUrl)
+                    .attributes(Map.of(QueueAttributeName.POLICY, policy))
+                    .build());
+
+            // Subscribe the queue to the topic
+            sns.subscribe(SubscribeRequest.builder()
+                    .topicArn(topicArn)
+                    .protocol("sqs")
+                    .endpoint(queueArn)
+                    .build());
+        }
+    }
+
+    @BeforeAll
+    void ensureDocker() {
+        Assumptions.assumeTrue(DOCKER_AVAILABLE, "Docker is not available; skipping LocalStack integration test");
+    }
+
+    @Test
+    @DisplayName("When notifications are disabled, function still returns metadata but no message reaches SQS")
+    void shouldReturnMetadataWhenNotificationsDisabled() {
+        Assumptions.assumeTrue(DOCKER_AVAILABLE, "Docker is not available; skipping LocalStack integration test");
+
+        // Given: a valid S3 event
+        S3Event event = TestS3EventFactory.create(
+                "meta-ping-bucket",
+                EXPECTED_FILE_NAME,
+                EXPECTED_FILE_SIZE
+        );
+
+        // When: function is invoked (metadata extraction should still happen)
+        String result = function.apply(event);
+
+        // Then: returned string contains extracted metadata
+        assertTrue(result.contains(EXPECTED_FILE_NAME));
+        assertTrue(result.contains(Long.toString(EXPECTED_FILE_SIZE)));
+        assertTrue(result.contains(EXPECTED_FILE_TYPE));
+
+        // And: no messages should be present in SQS
+        AwsBasicCredentials creds = AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey());
+        Region region = Region.of(localstack.getRegion());
+
+        try (SqsClient sqs = SqsClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(SQS))
+                .region(region)
+                .credentialsProvider(StaticCredentialsProvider.create(creds))
+                .build()) {
+
+            String qUrl = sqs.getQueueUrl(GetQueueUrlRequest.builder().queueName(QUEUE_NAME).build()).queueUrl();
+            boolean anyMessage = pollAnyMessage(sqs, qUrl);
+            assertFalse(anyMessage, "No messages should arrive when notifications are disabled");
+        }
+    }
+
+    private static boolean pollAnyMessage(SqsClient sqs, String queueUrl) {
+        Instant until = Instant.now().plus(Duration.ofSeconds(POLL_TIMEOUT_SECONDS));
+        while (Instant.now().isBefore(until)) {
+            List<Message> messages = sqs.receiveMessage(ReceiveMessageRequest.builder()
+                            .queueUrl(queueUrl)
+                            .maxNumberOfMessages(10)
+                            .waitTimeSeconds(LONG_POLL_SECONDS)
+                            .build())
+                    .messages();
+            if (!messages.isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/java/com/iam/metaping/integration/MetaPingS3ToSnsIT.java
+++ b/src/test/java/com/iam/metaping/integration/MetaPingS3ToSnsIT.java
@@ -44,7 +44,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @SpringBootTest
 @Testcontainers(disabledWithoutDocker = true)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class MetaPingApplicationTests extends AbstractLocalStackIT {
+class MetaPingS3ToSnsIT extends AbstractLocalStackIT {
 
     // Test constants
     private static final String TOPIC_NAME = "meta-ping-test";
@@ -164,7 +164,7 @@ class MetaPingApplicationTests extends AbstractLocalStackIT {
     private static String getQueueArnWithFallback(SqsClient sqs, String queueUrl) {
         String arn = getQueueArn(sqs, queueUrl);
         if (arn == null || arn.isBlank()) {
-            arn = String.format("arn:aws:sqs:%s:%s:%s", localstack.getRegion(), LOCALSTACK_ACCOUNT_ID, MetaPingApplicationTests.QUEUE_NAME);
+            arn = String.format("arn:aws:sqs:%s:%s:%s", localstack.getRegion(), LOCALSTACK_ACCOUNT_ID, MetaPingS3ToSnsIT.QUEUE_NAME);
         }
         return arn;
     }

--- a/src/test/java/com/iam/metaping/integration/helpers/AbstractLocalStackIT.java
+++ b/src/test/java/com/iam/metaping/integration/helpers/AbstractLocalStackIT.java
@@ -1,0 +1,59 @@
+package com.iam.metaping.integration.helpers;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sqs.SqsClient;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SNS;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+/**
+ * Base class for integration tests requiring LocalStack.
+ * Handles Docker availability checks and provides AWS client builders.
+ */
+public class AbstractLocalStackIT {
+
+
+    protected static final boolean DOCKER_AVAILABLE;
+    protected static final String LOCALSTACK_ACCOUNT_ID = "000000000000";
+
+    static {
+        boolean available;
+        try {
+            DockerClientFactory.instance().client();
+            available = true;
+        } catch (Throwable t) {
+            available = false;
+        }
+        DOCKER_AVAILABLE = available;
+    }
+
+    protected static SnsClient buildSnsClient(LocalStackContainer localstack) {
+        return SnsClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(SNS))
+                .region(Region.of(localstack.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .build();
+    }
+
+    protected static SqsClient buildSqsClient(LocalStackContainer localstack) {
+        return SqsClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(SQS))
+                .region(Region.of(localstack.getRegion()))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .build();
+    }
+
+    @BeforeAll
+    static void checkDockerAvailability() {
+        Assumptions.assumeTrue(DOCKER_AVAILABLE, "Docker is not available; skipping integration test");
+    }
+}

--- a/src/test/java/com/iam/metaping/integration/helpers/TestS3EventFactory.java
+++ b/src/test/java/com/iam/metaping/integration/helpers/TestS3EventFactory.java
@@ -1,0 +1,30 @@
+package com.iam.metaping.integration.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+
+import java.util.List;
+
+public class TestS3EventFactory {
+
+    public static S3Event create(String bucket, String key, long size) {
+        // Using the internal S3EventNotification models to build the hierarchy
+        S3EventNotification.S3BucketEntity bucketEntity = new S3EventNotification.S3BucketEntity(bucket, null, null);
+        S3EventNotification.S3ObjectEntity objectEntity = new S3EventNotification.S3ObjectEntity(key, size, null, null, null);
+        S3EventNotification.S3Entity s3Entity = new S3EventNotification.S3Entity(null, bucketEntity, objectEntity, null);
+
+        S3EventNotification.S3EventNotificationRecord eventRecord = new S3EventNotification.S3EventNotificationRecord(
+                "us-east-1",
+                "ObjectCreated:Put",
+                "aws:s3",
+                null,
+                "2.1",
+                null,
+                null,
+                s3Entity,
+                null
+        );
+
+        return new S3Event(List.of(eventRecord));
+    }
+}

--- a/src/test/java/com/iam/metaping/unit/SnsPublisherTests.java
+++ b/src/test/java/com/iam/metaping/unit/SnsPublisherTests.java
@@ -1,0 +1,117 @@
+package com.iam.metaping.unit;
+
+import com.iam.metaping.config.SnsProperties;
+import com.iam.metaping.service.SnsPublisher;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayName("Running unit tests for SnsPublisher")
+class SnsPublisherTests {
+
+    private SnsProperties configuredProps() {
+        SnsProperties props = new SnsProperties();
+        props.setTopicArn("arn:aws:sns:eu-west-1:123456789012:test-topic");
+        props.setRegion("eu-west-1");
+        return props;
+    }
+
+    @Test
+    @DisplayName("publish: configured client, with subject -> sends request and returns true")
+    void publishWithSubjectSuccess() {
+        // Given
+        SnsPublisher publisher = new SnsPublisher(configuredProps());
+        SnsClient sns = mock(SnsClient.class);
+        ReflectionTestUtils.setField(publisher, "snsClient", sns);
+
+        when(sns.publish(any(PublishRequest.class)))
+                .thenReturn(PublishResponse.builder().messageId("mid-1").build());
+
+        // When
+        boolean ok = publisher.publish("Hello", "World message");
+
+        // Then
+        assertTrue(ok);
+        ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+        verify(sns, times(1)).publish(captor.capture());
+        PublishRequest req = captor.getValue();
+        assertEquals("arn:aws:sns:eu-west-1:123456789012:test-topic", req.topicArn());
+        assertEquals("World message", req.message());
+        assertEquals("Hello", req.subject());
+    }
+
+    @Test
+    @DisplayName("publish: configured client, null subject -> subject omitted")
+    void publishWithoutSubject() {
+        // Given
+        SnsPublisher publisher = new SnsPublisher(configuredProps());
+        SnsClient sns = mock(SnsClient.class);
+        ReflectionTestUtils.setField(publisher, "snsClient", sns);
+        when(sns.publish(any(PublishRequest.class)))
+                .thenReturn(PublishResponse.builder().messageId("mid-2").build());
+
+        // When
+        boolean ok = publisher.publish(null, "Body");
+
+        // Then
+        assertTrue(ok);
+        ArgumentCaptor<PublishRequest> captor = ArgumentCaptor.forClass(PublishRequest.class);
+        verify(sns).publish(captor.capture());
+        PublishRequest req = captor.getValue();
+        assertEquals("Body", req.message());
+        assertNull(req.subject(), "Subject must be null when not provided");
+    }
+
+    @Test
+    @DisplayName("publish: blank message -> returns false and does not call SNS")
+    void blankMessageShortCircuits() {
+        // Given
+        SnsPublisher publisher = new SnsPublisher(configuredProps());
+        SnsClient sns = mock(SnsClient.class);
+        ReflectionTestUtils.setField(publisher, "snsClient", sns);
+
+        // When
+        assertFalse(publisher.publish("S", " \t\n"));
+
+        // Then
+        verify(sns, never()).publish(any(PublishRequest.class));
+    }
+
+    @Test
+    @DisplayName("publish: not configured (no topic/region) -> returns false")
+    void notConfiguredReturnsFalse() {
+        // Given
+        SnsProperties props = new SnsProperties();
+        // leave topicArn and region empty
+        SnsPublisher publisher = new SnsPublisher(props);
+
+        // When
+        assertFalse(publisher.publish("S", "Message"));
+    }
+
+    @Test
+    @DisplayName("publishJson: delegates to publish with same arguments")
+    void publishJsonDelegates() {
+        // Given
+        // Use not-configured to avoid real client build side-effects
+        SnsPublisher spyPublisher = spy(new SnsPublisher(new SnsProperties()));
+
+        String subject = "Sub";
+        String payload = "{\"k\":1}";
+
+        // When
+        // We don't stub publish; it will return false due to not-configured, which is fine.
+        boolean result = spyPublisher.publishJson(subject, payload);
+
+        // Then
+        assertFalse(result);
+        verify(spyPublisher, times(1)).publish(subject, payload);
+    }
+}


### PR DESCRIPTION
### Description

This pull request refactors existing test class names and adds enhanced test coverage for LocalStack integration. Details include:

- Renamed `MetaPingApplicationTests` to `MetaPingS3ToSnsIT` for better clarity.
- Introduced `AbstractLocalStackIT` to centralize Docker availability checks and AWS SDK v2 client builders for SNS/SQS.
- Added tests to verify the metadata notification flow:
  - `MetaPingApplicationTests` for SNS & SQS message verification.
  - `MetaPingNotificationsDisabledIT` to validate logic when notifications are disabled.
